### PR TITLE
fix: responsive logo edition

### DIFF
--- a/src/app/resultados/[id]/page.tsx
+++ b/src/app/resultados/[id]/page.tsx
@@ -45,6 +45,7 @@ export default function Page({ params }: {
   return (
     <>
       {isLoadingCronologia ? <TitleSkeleton/> :
+      <>
         <div className='relative flex justify-center items-center gap-4'>
           <Link 
             href={`/resultados/${Number(params.id) - 1}?${searchParams}`}
@@ -67,10 +68,14 @@ export default function Page({ params }: {
             ►
           </Link>
           {/* Logo en la esquina superior derecha */}
-          <div className='absolute top-0 right-0'>
+          <div className='hidden md:block absolute top-0 right-0'>
             <LogoEdicion id={Number(params.id)} />
           </div>
         </div>
+        <div className='md:hidden flex justify-center items-center my-3'>
+          <LogoEdicion id={Number(params.id)} />
+        </div>
+      </>
       }
       <Chips chips={[{
         text: 'Estadísticas',


### PR DESCRIPTION
En este PR se arregla el logo que se muestra en la vista individual de un año cuando el dispositivo es un celular o similar. 
<img width="158" alt="image" src="https://github.com/user-attachments/assets/d6da5d8d-6ba1-48fc-a703-ce5445d7df2a" />
